### PR TITLE
cmsis-dap elaphurelink: fix invalid free on shutdown

### DIFF
--- a/cmsis_dap_elaphurelink.c
+++ b/cmsis_dap_elaphurelink.c
@@ -604,6 +604,10 @@ static void cmsis_dap_elaphurelink_close(struct cmsis_dap *dap)
 	uv_mutex_destroy(&ctx->read_producer_mutex);
 	uv_mutex_destroy(&ctx->read_consumer_mutex);
 	free(ctx);
+	/* dap->packet_buffer aliased ctx->command_response_buffer (see open()); ctx is now
+	 * freed, so clear it to stop cmsis_dap_close() free()-ing a dangling interior pointer. */
+	dap->bdata = NULL;
+	dap->packet_buffer = NULL;
 }
 
 static int cmsis_dap_elaphurelink_read(struct cmsis_dap *dap, int transfer_timeout_ms, struct timeval *wait_timeout)


### PR DESCRIPTION
On shutdown, OpenOCD aborts with `free(): invalid pointer`.

### Cause
`cmsis_dap_elaphurelink_open()` allocates the context as one block and aliases the packet buffer into it:

```c
ctx = calloc(1, sizeof(*ctx));
dap->bdata = (struct cmsis_dap_backend_data *)ctx;
dap->packet_buffer = ctx->command_response_buffer;   // interior pointer, not its own allocation
```

`command_response_buffer` is an inline `uint8_t[MTU_SIZE]` member of the context, so `dap->packet_buffer` points into the middle of the `ctx` allocation.

On teardown, `cmsis_dap_elaphurelink_close()` does `free(ctx)`, and then the generic `cmsis_dap_close()` runs `free(dap->packet_buffer)`. That hands the allocator an interior pointer to an already-freed block, which is undefined behavior and aborts with `free(): invalid pointer`.

Backtrace tip was `free()` from `cmsis_dap_close()` (`src/jtag/drivers/cmsis_dap.c`) via `cmsis_dap_quit` -> `adapter_quit`.

### Fix
After freeing `ctx`, clear the aliased pointers so the generic close has nothing stale to free (`free(NULL)` is a no-op):

```c
free(ctx);
dap->bdata = NULL;
dap->packet_buffer = NULL;
```

The backend never makes a separate allocation for `packet_buffer` (its `alloc`/`free` hooks are no-ops; the alias to `ctx->command_response_buffer` is the only value it ever holds), so `free(ctx)` is the complete and correct cleanup.

### Test
Built from source on arm64 (Raspberry Pi) and x86-free Apple Silicon. Before the change, connecting through an ESP32 CMSIS-DAP probe and shutting down aborts with `free(): invalid pointer`. After the change, the same flow exits cleanly (exit code 0). The two NULL stores are confirmed present in the compiled `cmsis_dap_elaphurelink_close()`.